### PR TITLE
[WIP] refactor and add Azure Lua 5.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/fiatjaf/lunatico
 
 go 1.14
 
-require github.com/aarzilli/golua v0.0.0-20190714183732-fc27908ace94
+
+require (
+	github.com/Azure/golua v0.0.0-20190201163710-5105380e8196
+	github.com/aarzilli/golua v0.0.0-20190714183732-fc27908ace94
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Azure/golua v0.0.0-20190201163710-5105380e8196 h1:MsDn6eUTEWKjZXDV1oz0NLuj8ikiBnjVhq08MFzaiEI=
+github.com/Azure/golua v0.0.0-20190201163710-5105380e8196/go.mod h1:Qtqr8Y+5vWnmz/4RWerkYOJfugBu9ViPCFC8yvvFL5I=
 github.com/aarzilli/golua v0.0.0-20190714183732-fc27908ace94 h1:BdnmhcIVWErdfypFo/f9Ai2KoC2BpkLpGSyv0aquYuI=
 github.com/aarzilli/golua v0.0.0-20190714183732-fc27908ace94/go.mod h1:SV7PRru1lATaCdZXNt5AZHw0uKiN1BoYBHrcctQ1Ouc=
 github.com/aarzilli/golua v0.0.0-20200214131735-421e0de0aa20 h1:bvuZt14rsLws65bIf85LLfA1WHrsy+WZtP3mJZ4iw0g=

--- a/lunaticotest.go
+++ b/lunaticotest.go
@@ -3,15 +3,15 @@ package lunatico
 import (
 	"errors"
 	"testing"
-
-	"github.com/aarzilli/golua/lua"
 )
 
-func TestBasic(t *testing.T) {
-	L := lua.NewState()
-	defer L.Close()
-	L.OpenLibs()
+type LuaStateForTest interface {
+	LuaState
 
+	DoString(str string) error
+}
+
+func RunTestBasic(t *testing.T, L LuaStateForTest) {
 	SetGlobals(L, map[string]interface{}{
 		"fromgo": 10,
 	})
@@ -31,11 +31,7 @@ func TestBasic(t *testing.T) {
 	}
 }
 
-func TestFunctions(t *testing.T) {
-	L := lua.NewState()
-	defer L.Close()
-	L.OpenLibs()
-
+func RunTestFunctions(t *testing.T, L LuaStateForTest) {
 	SetGlobals(L, map[string]interface{}{
 		"multiply": func(v int, times int) int { return v * times },
 		"sum": func(xx ...interface{}) (res uint64) {
@@ -148,11 +144,7 @@ func TestFunctions(t *testing.T) {
 	}
 }
 
-func TestSomeValues(t *testing.T) {
-	L := lua.NewState()
-	defer L.Close()
-	L.OpenLibs()
-
+func RunTestSomeValues(t *testing.T, L LuaStateForTest) {
 	SetGlobals(L, map[string]interface{}{
 		"x": map[string]interface{}{
 			"k": []float64{1.123, 8, 999999999999},

--- a/wrappers/aarzilli/aarzilli.go
+++ b/wrappers/aarzilli/aarzilli.go
@@ -1,0 +1,74 @@
+package aarzilli
+
+import (
+	"github.com/aarzilli/golua/lua"
+	"github.com/fiatjaf/lunatico"
+)
+
+// Wrapper type.
+
+type LuaState struct {
+	*lua.State
+}
+
+func (L LuaState) Type(index int) int {
+	return int(L.State.Type(index))
+}
+
+func (L LuaState) PushGoFunction(f func(lunatico.LuaState) int) {
+	L.State.PushGoFunction(func(L *lua.State) int {
+		l := LuaState{State: L}
+		return f(l)
+	})
+}
+
+func (L LuaState) Next(index int) bool {
+	return L.State.Next(index) != 0
+}
+
+// Wrapper functions to use as drop-in replacement for old lunatico.
+
+func SetGlobals(L *lua.State, globals map[string]interface{}) {
+	l := LuaState{State: L}
+	lunatico.SetGlobals(l, globals)
+}
+
+func GetGlobals(L *lua.State, names ...string) map[string]interface{} {
+	l := LuaState{State: L}
+	return lunatico.GetGlobals(l, names...)
+}
+
+func GetFullStack(L *lua.State) []interface{} {
+	l := LuaState{State: L}
+	return lunatico.GetFullStack(l)
+}
+
+func ReadAny(L *lua.State, pos int) interface{} {
+	l := LuaState{State: L}
+	return lunatico.ReadAny(l, pos)
+}
+
+func ReadString(L *lua.State, pos int) (v string) {
+	l := LuaState{State: L}
+	return lunatico.ReadString(l, pos)
+}
+
+func ReadTable(L *lua.State, pos int) interface{} {
+	l := LuaState{State: L}
+	return lunatico.ReadTable(l, pos)
+}
+
+func PushMap(L *lua.State, m map[string]interface{}) {
+	l := LuaState{State: L}
+	lunatico.PushMap(l, m)
+}
+
+func PushSlice(L *lua.State, s []interface{}) {
+	l := LuaState{State: L}
+	lunatico.PushSlice(l, s)
+}
+
+func PushAny(L *lua.State, ival interface{}) {
+	l := LuaState{State: L}
+	lunatico.PushAny(l, ival)
+}

--- a/wrappers/aarzilli/aarzilli_test.go
+++ b/wrappers/aarzilli/aarzilli_test.go
@@ -1,0 +1,32 @@
+package aarzilli
+
+import (
+	"testing"
+
+	"github.com/aarzilli/golua/lua"
+	"github.com/fiatjaf/lunatico"
+)
+
+func TestBasic(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	L.OpenLibs()
+	l := LuaState{State: L}
+	lunatico.RunTestBasic(t, l)
+}
+
+func TestFunctions(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	L.OpenLibs()
+	l := LuaState{State: L}
+	lunatico.RunTestFunctions(t, l)
+}
+
+func TestSomeValues(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	L.OpenLibs()
+	l := LuaState{State: L}
+	lunatico.RunTestSomeValues(t, l)
+}

--- a/wrappers/azure/azure.go
+++ b/wrappers/azure/azure.go
@@ -1,0 +1,151 @@
+package azure
+
+import (
+	"github.com/Azure/golua/lua"
+	"github.com/fiatjaf/lunatico"
+)
+
+// Wrapper type.
+
+type LuaState struct {
+	*lua.State
+}
+
+var azure2lua = [9]int{
+	lua.NoneType:     lunatico.LUA_TNONE,
+	lua.NilType:      lunatico.LUA_TNIL,
+	lua.BoolType:     lunatico.LUA_TBOOLEAN,
+	lua.NumberType:   lunatico.LUA_TNUMBER,
+	lua.StringType:   lunatico.LUA_TSTRING,
+	lua.FuncType:     lunatico.LUA_TFUNCTION,
+	lua.UserDataType: lunatico.LUA_TUSERDATA,
+	lua.ThreadType:   lunatico.LUA_TTHREAD,
+	lua.TableType:    lunatico.LUA_TTABLE,
+}
+
+func (L LuaState) Type(index int) int {
+	return azure2lua[L.State.TypeAt(index)]
+}
+
+func (L LuaState) PushGoFunction(f func(lunatico.LuaState) int) {
+	wrapper := func(L *lua.State) int {
+		l := LuaState{State: L}
+		return f(l)
+	}
+	L.State.PushClosure(wrapper, 0)
+}
+
+func (L LuaState) CreateTable(narr int, nrec int) {
+	L.State.NewTableSize(narr, nrec)
+}
+
+func (L LuaState) GetGlobal(name string) {
+	L.State.GetGlobal(name)
+}
+
+func (L LuaState) GetTop() int {
+	return L.State.Top()
+}
+
+func (L LuaState) ObjLen(index int) uint {
+	length := L.State.RawLen(index)
+
+	// Cut "holes" from the end of the table.
+	for length > 0 {
+		typ := L.State.RawGetIndex(index, length)
+		L.State.Pop()
+		if typ != lua.NoneType && typ != lua.NilType {
+			break
+		}
+		length--
+	}
+
+	return uint(length)
+}
+
+func (L LuaState) Pop(n int) {
+	L.State.PopN(n)
+}
+
+func (L LuaState) PushString(str string) {
+	L.State.Push(str)
+}
+
+func (L LuaState) PushNumber(n float64) {
+	L.State.Push(n)
+}
+
+func (L LuaState) PushBoolean(b bool) {
+	L.State.Push(b)
+}
+
+func (L LuaState) PushNil() {
+	L.State.Push(nil)
+}
+
+func (L LuaState) RaiseError(msg string) {
+	L.State.Errorf("%s", msg)
+}
+
+func (L LuaState) RawSeti(index int, n int) {
+	L.State.RawSetIndex(index, n)
+}
+
+func (L LuaState) ToBoolean(index int) bool {
+	return L.State.ToBool(index)
+}
+
+func (L LuaState) ToInteger(index int) int {
+	return int(L.State.ToInt(index))
+}
+
+func (L LuaState) DoString(str string) error {
+	return L.State.ExecText(str)
+}
+
+// Wrapper functions to use as drop-in replacement for old lunatico.
+
+func SetGlobals(L *lua.State, globals map[string]interface{}) {
+	l := LuaState{State: L}
+	lunatico.SetGlobals(l, globals)
+}
+
+func GetGlobals(L *lua.State, names ...string) map[string]interface{} {
+	l := LuaState{State: L}
+	return lunatico.GetGlobals(l, names...)
+}
+
+func GetFullStack(L *lua.State) []interface{} {
+	l := LuaState{State: L}
+	return lunatico.GetFullStack(l)
+}
+
+func ReadAny(L *lua.State, pos int) interface{} {
+	l := LuaState{State: L}
+	return lunatico.ReadAny(l, pos)
+}
+
+func ReadString(L *lua.State, pos int) (v string) {
+	l := LuaState{State: L}
+	return lunatico.ReadString(l, pos)
+}
+
+func ReadTable(L *lua.State, pos int) interface{} {
+	l := LuaState{State: L}
+	return lunatico.ReadTable(l, pos)
+}
+
+func PushMap(L *lua.State, m map[string]interface{}) {
+	l := LuaState{State: L}
+	lunatico.PushMap(l, m)
+}
+
+func PushSlice(L *lua.State, s []interface{}) {
+	l := LuaState{State: L}
+	lunatico.PushSlice(l, s)
+}
+
+func PushAny(L *lua.State, ival interface{}) {
+	l := LuaState{State: L}
+	lunatico.PushAny(l, ival)
+}

--- a/wrappers/azure/azure_test.go
+++ b/wrappers/azure/azure_test.go
@@ -1,0 +1,33 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/Azure/golua/lua"
+	"github.com/Azure/golua/std"
+	"github.com/fiatjaf/lunatico"
+)
+
+func TestBasic(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	std.Open(L)
+	l := LuaState{State: L}
+	lunatico.RunTestBasic(t, l)
+}
+
+func TestFunctions(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	std.Open(L)
+	l := LuaState{State: L}
+	lunatico.RunTestFunctions(t, l)
+}
+
+func TestSomeValues(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	std.Open(L)
+	l := LuaState{State: L}
+	lunatico.RunTestSomeValues(t, l)
+}


### PR DESCRIPTION
I made an interface for LuaState and supported multiple implementations of Lua.

The original implementation using `github.com/aarzilli/golua` was moved to `wrappers/aarzilli` as a wrapper, it can be imported and works exactly as the original package.

Azure implementation was added under `wrappers/azure`. It passes the test taking the following into account:
 * [ ] this PR applied: https://github.com/Azure/golua/pull/61
 * [ ] azure's package has a bug with determining length of a table (not cutting tail `nil`s) for which I made a workaround in the wrapper.
 * [ ] I noticed that it has only RawLen and [raises "unimplemented"](https://github.com/Azure/golua/blob/5105380e819643c4fcf1ab813a32900ee4786916/lua/lua.go#L169) for normal Length (used for `#`).
 * [ ] it [uses external luac](https://github.com/Azure/golua/blob/5105380e819643c4fcf1ab813a32900ee4786916/lua/state.go#L305) for compilation to bytecode.